### PR TITLE
Set initial correctTotal and correctTotal in resetTask to zero

### DIFF
--- a/src/scripts/h5p-dictation.js
+++ b/src/scripts/h5p-dictation.js
@@ -92,7 +92,7 @@ class Dictation extends H5P.Question {
     if (!params) {
       return;
     }
-
+    this.correctTotal = 0;
     this.contentId = contentId;
     this.contentData = contentData || {};
 
@@ -528,6 +528,7 @@ class Dictation extends H5P.Question {
 
       this.mistakesCapped = this.maxMistakes;
       this.isAnswered = false;
+      this.correctTotal = 0;
     };
 
     /**


### PR DESCRIPTION
When Dictation is included inside an H5P interactive book, this fix will initialize the Dictation score (correctTotal) to 0 and reset it to 0 when the IB is reset ("Restart").